### PR TITLE
Updates to result icons

### DIFF
--- a/src/Kind2.ts
+++ b/src/Kind2.ts
@@ -161,7 +161,7 @@ export class Kind2 implements TreeDataProvider<TreeNode>, CodeLensProvider {
         }
         
         for (const property of component.properties) {
-          if (decorations.has(property.uri)) {
+          if (decorations.has(property.uri) && (property.line != component.line) && (property.line != component.contractLine)) {
             let decorationOptions: DecorationOptions = { range: new Range(new Position(property.line, 0), (new Position(property.line, 100))) };
             decorations.get(property.uri)?.get(property.state)?.push(decorationOptions);
           }
@@ -346,7 +346,7 @@ export class Kind2 implements TreeDataProvider<TreeNode>, CodeLensProvider {
         modifiedComponents.push(component);
       }
       if (results.length == 0) {
-        mainComponent.state = ["passed"];
+        mainComponent.state = ["unknown"];
       }
     }).catch(reason => {
       if (reason.message.includes("cancelled")) {

--- a/src/treeNode.ts
+++ b/src/treeNode.ts
@@ -114,10 +114,10 @@ export class Component {
     if (failedProperties.size !== 0) {
       return ["failed"];
     }
-    if (unknownProperties.size !== 0) {
-      return ["unknown"];
+    if (passedProperties.size !== 0) {
+      return ["passed"]
     }
-    return ["passed"];
+    return ["unknown"];
   }
   containsUnrealizable() {
     return this.state.some(str => str.includes("unrealizable"))


### PR DESCRIPTION
Ignore ref type prop result icon if overlapping with node or contract start line, and give unknown icon if results are empty (makes array bug a bit better because we now give a question mark rather than a green check)