### PR TITLE
Update buttons for type decls

### DIFF
--- a/src/treeNode.ts
+++ b/src/treeNode.ts
@@ -21,16 +21,22 @@ export class File implements File {
 }
 
 export type RealizabilityResult = "realizable" | "unrealizable"
-export type RealizabilitySource = "inputs" | "contract" | "imported node"
+export type RealizabilitySource = "inputs" | "contract" | "imported node" | "type"
 
 export class Component {
   private _state: State[];
   private _analyses: Analysis[];
   private _imported: boolean;
+  private _typeDecl: boolean;
+  private _hasRefType: boolean;
   set analyses(analyses: Analysis[]) { this._analyses = analyses; }
   get analyses(): Analysis[] { return this._analyses; }
   set imported(imported: boolean) { this._imported = imported; }
   get imported(): boolean { return this._imported; }
+  set typeDecl(typeDecl: boolean) { this._typeDecl = typeDecl; }
+  get typeDecl(): boolean { return this._typeDecl; }
+  set hasRefType(hasRefType: boolean) { this._hasRefType = hasRefType; }
+  get hasRefType(): boolean { return this._hasRefType; }
   set state(state: State[]) {
     if (this._analyses.length == 0) {
       this._state = state;
@@ -88,17 +94,27 @@ export class Component {
         if (property.state === "unknown") { unknownProperties.add(property.name); }
         if (property.state === "errored") { erroredProperties.add(property.name); }
       }
+      // "Trivial" type declaration realizability checks give a question mark
+      if (analysis.realizability === "realizable" && !this.hasRefType) {
+        return ["unknown"]
+      }
       if (analysis.realizability === "realizable" && analysis.realizabilitySource === "contract") { 
         ret.push("contract realizable"); 
       }
       if (analysis.realizability === "realizable" && analysis.realizabilitySource === "inputs") { 
         ret.push("inputs realizable"); 
       }
+      if (analysis.realizability === "realizable" && analysis.realizabilitySource === "type") { 
+        ret.push("type realizable"); 
+      }
       if (analysis.realizability === "unrealizable" && analysis.realizabilitySource === "contract") { 
         ret.push("contract unrealizable"); 
       }
       if (analysis.realizability === "unrealizable" && analysis.realizabilitySource === "inputs") { 
         ret.push("inputs unrealizable"); 
+      }
+      if (analysis.realizability === "unrealizable" && analysis.realizabilitySource === "type") { 
+        ret.push("type unrealizable"); 
       }
     }
     if (ret.length !== 0) {
@@ -123,10 +139,12 @@ export class Component {
     return this.state.some(str => str.includes("unrealizable"))
   }
   get uri(): string { return this.parent.uri; }
-  constructor(readonly name: string, readonly line: number, readonly contractLine: number, readonly parent: File, readonly imported_comp: string) {
+  constructor(readonly name: string, readonly line: number, readonly contractLine: number, readonly parent: File, readonly importedComp: string, readonly compKind: string, readonly hasRefinementType: boolean) {
     this._state = ["pending"];
     this._analyses = [];
-    this._imported = imported_comp === "true";
+    this._imported = importedComp === "true";
+    this._typeDecl = compKind === "typeDecl";
+    this._hasRefType = hasRefinementType;
   }
 }
 
@@ -158,7 +176,8 @@ export class Property {
 export type State = 
   "pending" | "running" | "passed" | "reachable" | "failed" | "unreachable" 
 | "unknown" | "stopped" | "errored" | "realizable" | "unrealizable" | "inputs realizable"
-| "inputs unrealizable" | "contract realizable" | "contract unrealizable";
+| "inputs unrealizable" | "contract realizable" | "contract unrealizable"
+| "type realizable" | "type unrealizable";
 
 export function statePath(state: State) {
   switch (state) {
@@ -170,6 +189,7 @@ export function statePath(state: State) {
     case "reachable":
     case "contract realizable":
     case "inputs realizable": 
+    case "type realizable":
     case "realizable":
       return "icons/passed.svg";
     case "failed":
@@ -177,6 +197,7 @@ export function statePath(state: State) {
     case "unrealizable":
     case "inputs unrealizable":
     case "contract unrealizable":
+    case "type unrealizable":
       return "icons/failed.svg";
     case "unknown":
       return "icons/unknown.svg";
@@ -197,6 +218,7 @@ export function stateIcon(state: State) {
     case "reachable":
     case "contract realizable":
     case "inputs realizable": 
+    case "type realizable":
     case "realizable":
       return new ThemeIcon("$(testing-passed-icon)", new ThemeColor("testing.iconPassed"));
     case "failed":
@@ -204,6 +226,7 @@ export function stateIcon(state: State) {
     case "unrealizable":
     case "inputs unrealizable":
     case "contract unrealizable":
+    case "type unrealizable":
       return new ThemeIcon("$(testing-failed-icon)", new ThemeColor("testing.iconFailed"));
     case "unknown":
       return new ThemeIcon("$(question)", new ThemeColor("testing.iconQueued"));


### PR DESCRIPTION
Make type declaration buttons behave more consistently with property checking buttons. That is, "check realizability" buttons will now appear for every type declaration, but if the check is trivial (nothing interesting is checked), the extension will report a question mark rather than a check or x.