### PR TITLE
Add otherwise to control keywords

### DIFF
--- a/syntaxes/lustre.tmLanguage.json
+++ b/syntaxes/lustre.tmLanguage.json
@@ -715,7 +715,7 @@
         {
           "comment": "Keywords",
           "name": "keyword.control.lustre",
-          "match": "\\b(if|then|else|not|and|xor|or|pre|fby|div|mod|lsh|rsh|reachable|provided|assuming|invariant|from|within|at|any)\\b"
+          "match": "\\b(if|then|else|otherwise|not|and|xor|or|pre|fby|div|mod|lsh|rsh|reachable|provided|assuming|invariant|from|within|at|any)\\b"
         },
         {
           "comment": "Merge",


### PR DESCRIPTION
Adds otherwise to highlighted keywords like `if`, `then`, `else`, etc.