### PR TITLE
Add syntax highlighting for datatype declarations and match expressions

### DIFF
--- a/syntaxes/lustre.tmLanguage.json
+++ b/syntaxes/lustre.tmLanguage.json
@@ -13,6 +13,9 @@
       "include": "#typeDecl"
     },
     {
+      "include": "#datatypeDecl"
+    },
+    {
       "include": "#const"
     },
     {
@@ -713,6 +716,9 @@
           "include": "#comment"
         },
         {
+          "include": "#matchBlock"
+        },
+        {
           "comment": "Keywords",
           "name": "keyword.control.lustre",
           "match": "\\b(if|then|else|otherwise|not|and|xor|or|pre|fby|div|mod|lsh|rsh|reachable|provided|assuming|invariant|from|within|at|any|when|cond|end)\\b"
@@ -1409,6 +1415,202 @@
             },
             {
               "include": "#comment"
+            }
+          ]
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "datatypeDecl": {
+      "comment": "Algebraic datatype declaration.",
+      "begin": "\\b(datatype)\\b\\s*(\\w+)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.lustre"
+        },
+        "2": {
+          "name": "support.type.lustre"
+        }
+      },
+      "end": ";",
+      "patterns": [
+        {
+          "comment": "Type parameters.",
+          "begin": "<",
+          "end": ">",
+          "patterns": [
+            {
+              "name": "support.type.lustre",
+              "match": "\\w+"
+            },
+            {
+              "include": "#comment"
+            }
+          ]
+        },
+        {
+          "comment": "Constructors.",
+          "begin": "=",
+          "beginCaptures": {
+            "0": {
+              "name": "keyword.operator.lustre"
+            }
+          },
+          "end": "(?=;)",
+          "patterns": [
+            {
+              "name": "keyword.operator.lustre",
+              "match": "\\|"
+            },
+            {
+              "comment": "Constructor with argument types.",
+              "begin": "(\\w+)\\s*\\(",
+              "beginCaptures": {
+                "1": {
+                  "name": "entity.name.tag.lustre"
+                }
+              },
+              "end": "\\)",
+              "patterns": [
+                {
+                  "include": "#type"
+                },
+                {
+                  "include": "#comment"
+                }
+              ]
+            },
+            {
+              "comment": "Nullary constructor.",
+              "name": "entity.name.tag.lustre",
+              "match": "\\w+"
+            },
+            {
+              "include": "#comment"
+            }
+          ]
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "matchPattern": {
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "comment": "Constructor applied to sub-patterns.",
+          "begin": "(\\w+)\\s*\\(",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.tag.lustre"
+            }
+          },
+          "end": "\\)",
+          "patterns": [
+            {
+              "include": "#matchPattern"
+            },
+            {
+              "name": "keyword.operator.lustre",
+              "match": ","
+            }
+          ]
+        },
+        {
+          "comment": "Wildcard or bound variable.",
+          "name": "variable.other.lustre",
+          "match": "[a-z_]\\w*"
+        },
+        {
+          "comment": "Nullary constructor.",
+          "name": "entity.name.tag.lustre",
+          "match": "[A-Z]\\w*"
+        }
+      ]
+    },
+    "matchBlock": {
+      "begin": "\\b(match)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.lustre"
+        }
+      },
+      "end": "\\b(end)\\b",
+      "endCaptures": {
+        "1": {
+          "name": "keyword.control.lustre"
+        }
+      },
+      "patterns": [
+        {
+          "comment": "Matched expression.",
+          "begin": "(?<=match)",
+          "end": "\\b(with)\\b",
+          "endCaptures": {
+            "1": {
+              "name": "keyword.control.lustre"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#matchBlock"
+            },
+            {
+              "include": "#expression"
+            },
+            {
+              "include": "#comment"
+            }
+          ]
+        },
+        {
+          "comment": "Cases.",
+          "begin": "\\|",
+          "beginCaptures": {
+            "0": {
+              "name": "keyword.operator.lustre"
+            }
+          },
+          "end": "(?=\\||\\bend\\b)",
+          "patterns": [
+            {
+              "comment": "Pattern.",
+              "begin": "(?<=\\|)",
+              "end": "(?=:)",
+              "patterns": [
+                {
+                  "include": "#matchPattern"
+                },
+                {
+                  "include": "#comment"
+                }
+              ]
+            },
+            {
+              "comment": "Case body.",
+              "begin": ":",
+              "beginCaptures": {
+                "0": {
+                  "name": "keyword.operator.lustre"
+                }
+              },
+              "end": "(?=\\||\\bend\\b)",
+              "patterns": [
+                {
+                  "include": "#matchBlock"
+                },
+                {
+                  "include": "#expression"
+                },
+                {
+                  "include": "#comment"
+                }
+              ]
             }
           ]
         },


### PR DESCRIPTION
## Summary

Extends the Lustre TextMate grammar to highlight two recently added Kind2 constructs:

- **Datatype declarations** — `datatype Name<T> = C1 | C2(T) | ...;`
  - `datatype` keyword, the type name, and type parameters
  - Constructors as tags, with `|` separators and constructor argument types
  - Supports the leading-`|` form and multi-line declarations
- **Match expressions** — `match e with | Pattern : body | ... end`
  - `match`/`with`/`end` keywords, `|` and `:` operators
  - Patterns: constructors as tags, bound variables and wildcards as variables
  - Nested patterns (e.g. `Wrap(B(n))`) and matches used as call arguments

## Testing

Tokenization was verified with `vscode-textmate` against example `.lus` files exercising each form (polymorphic datatypes, nested matches, match-as-argument, multi-line/leading-`|` declarations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)